### PR TITLE
Add keyring support

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,18 +19,21 @@ $ node src/index.js -h
 Usage: explorer-ui-server [options]
 
 Options:
-  --version      Show version number                                   [boolean]
-  -s, --service  service-for path                                  [default: ""]
-  -b, --path     base path uri
-  -d, --dir      base dir                         [required] [default: "../app"]
-  -p, --port     listening port
-  -k, --key      server key                                        [default: ""]
-  -c, --cert     server cert                                       [default: ""]
-  -x, --pfx      server pfx                                        [default: ""]
-  -w, --pass     server pfx passphrase                             [default: ""]
-  -f, --csp      csp whitelist ancestors frames                       [required]
-  -v, --verbose  show request logs                    [boolean] [default: false]
-  -h, --help     Show help                                             [boolean]
+  --version             Show version number                                   [boolean]
+  -s, --service         service-for path                                  [default: ""]
+  -b, --path            base path uri
+  -d, --dir             base dir                         [required] [default: "../app"]
+  -p, --port            listening port
+  -k, --key             server key                                        [default: ""]
+  -c, --cert            server cert                                       [default: ""]
+  -x, --pfx             server pfx                                        [default: ""]
+  -w, --pass            server pfx passphrase                             [default: ""]
+  -n, --keyring         keyring name                                      [default: ""]
+  -o, --keyring-owner   keyring owner id                                  [default: ""]
+  -l, --keyring-label   keyring certificate label                         [default: ""]
+  -f, --csp             csp whitelist ancestors frames                       [required]
+  -v, --verbose         show request logs                    [boolean] [default: false]
+  -h, --help            Show help                                             [boolean]
 ```
 
 ## Run Tests

--- a/package-lock.json
+++ b/package-lock.json
@@ -1235,6 +1235,15 @@
         "graceful-fs": "^4.1.6"
       }
     },
+    "keyring_js": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/keyring_js/-/keyring_js-1.0.1.tgz",
+      "integrity": "sha512-A5vMeGoSHnFuveee7OjyNFJd9Mo+yZs4weLIhegCvBu/3OjgFUNmeWUFbM4NwX/FBz3/lGX4uB8E/jpgjd8VwA==",
+      "optional": true,
+      "requires": {
+        "node-gyp-build": "^4.2.1"
+      }
+    },
     "lcid": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/lcid/-/lcid-2.0.0.tgz",
@@ -1887,6 +1896,12 @@
         "object.getownpropertydescriptors": "^2.0.3",
         "semver": "^5.7.0"
       }
+    },
+    "node-gyp-build": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.2.2.tgz",
+      "integrity": "sha512-Lqh7mrByWCM8Cf9UPqpeoVBBo5Ugx+RKu885GAzmLBVYjeywScxHXPGLa4JfYNZmcNGwzR0Glu5/9GaQZMFqyA==",
+      "optional": true
     },
     "normalize-package-data": {
       "version": "2.5.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "explorer-ui-server",
-  "version": "0.2.11",
+  "version": "0.2.12",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,9 @@
   "dependencies": {
     "yargs": "^12.0.5"
   },
+  "optionalDependencies": {
+    "keyring_js": "~1.0.0"
+  },
   "devDependencies": {
     "axios": "^0.19.0",
     "chai": "^4.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "explorer-ui-server",
-  "version": "0.2.11",
+  "version": "0.2.12",
   "description": "HTTP Server to host static files",
   "author": "IBM",
   "license": "EPL-2",

--- a/src/index.js
+++ b/src/index.js
@@ -173,7 +173,6 @@ const serviceFor = config['service-for'] || name;
 //load keyring
 if (config.https.key === '' && config.https.cert === '') {
   process.stdout.write(`[${serviceFor}] key and certificate not found, attempting to load from keyring\n`);
-  process.stdout.write(`[${argv.n}] \n`);
   if ((argv.o > '' || argv.o) && (argv.n > '' || argv.n ) && (argv.l > '' || argv.l)){
     if (keyring_js) {
       try {


### PR DESCRIPTION
adds ability to load certificates from keyrings on z/OS
new options:
-n, --keyring              keyring name 
-o, --keyring-owner   keyring owner id   
-l, --keyring-label       keyring certificate label 

keyring options are used when certificates are not loaded via -c and -k options