### PR TITLE
add keyring support

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -11,7 +11,9 @@
             "program": "${workspaceFolder}\\src\\index.js",
              //"args": ["-s", "jes", "-b", "/ui/v1/explorer-jes", "-p", "7554", "-k", "C:\\zowe\\explorer-componentisation\\configs\\server.key", "-c", "C:\\zowe\\explorer-componentisation\\configs\\server.cert", "-x", "", "-w", "", "-f", "https://tvt5003.svl.ibm.com"],
              //"args": [ "-s", "jes", "-b", "/", "-p", "9090", "-f", "https://test.zowe.org/*", "-k", "configs/server.key", "-c", "configs/server.cert" ]
-             "args": [ "-s", "", "-b", "/relpath", "-d", "public","-p", "9090", "-f", "https://test.zowe.org/*", "-k", "configs/server.key", "-c", "configs/server.cert" ]
+             //"args": [ "-s", "", "-b", "/cache", "-d", "public/cache","-p", "9090", "-f", "https://test.zowe.org/*", "-k", "configs/server.key", "-c", "configs/server.cert" ]
+             "args": ["-s", "jes", "-b", "/", "-d", "public", "-p", "9090", "-x", "configs/server.pfx", "-w", "pass"]
+             //"args": ["-s", "jes", "-b", "/", "-d", "public", "-p", "9090", "-k","configs/server.key","-c","configs/server.cert","-x","configs/server.pfx","-w","pass","-n","keyring","-o","owner","-l","label","-v"]
         },
         {
             "type": "node",
@@ -36,7 +38,7 @@
                 "--timeout",
                 "999999",
                 "--colors",
-                "${workspaceFolder}\\test\\relpath\\test-relpath.js"
+                "${workspaceFolder}\\test\\https-combos\\test-https-combo.js"
             ],
             "console": "integratedTerminal",
             "internalConsoleOptions": "neverOpen"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -59,7 +59,7 @@ node('ibm-jenkins-slave-nvm') {
     scannerTool     : lib.Constants.DEFAULT_LFJ_SONARCLOUD_SCANNER_TOOL,
     scannerServer   : lib.Constants.DEFAULT_LFJ_SONARCLOUD_SERVER,
     allowBranchScan : lib.Constants.DEFAULT_LFJ_SONARCLOUD_ALLOW_BRANCH,
-    failBuild       : lib.Constants.DEFAULT_LFJ_SONARCLOUD_FAIL_BUILD
+    failBuild       : false
   )
 
   // define we need publish stage

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -30,7 +30,9 @@ node('ibm-jenkins-slave-nvm') {
     publishRegistry: [
       email                      : lib.Constants.DEFAULT_LFJ_NPM_PRIVATE_REGISTRY_EMAIL,
       usernamePasswordCredential : lib.Constants.DEFAULT_LFJ_NPM_PRIVATE_REGISTRY_CREDENTIAL,
-    ]
+    ],
+    // FIXME: ideally this should set to false (using default by remove this line)
+    ignoreAuditFailure            : true,
   )
 
   // build stage is required

--- a/README.md
+++ b/README.md
@@ -19,18 +19,21 @@ $ node src/index.js -h
 Usage: explorer-ui-server [options]
 
 Options:
-  --version      Show version number                                   [boolean]
-  -s, --service  service-for path                                  [default: ""]
-  -b, --path     base path uri
-  -d, --dir      base dir                         [required] [default: "../app"]
-  -p, --port     listening port
-  -k, --key      server key                                        [default: ""]
-  -c, --cert     server cert                                       [default: ""]
-  -x, --pfx      server pfx                                        [default: ""]
-  -w, --pass     server pfx passphrase                             [default: ""]
-  -f, --csp      csp whitelist ancestors frames                       [required]
-  -v, --verbose  show request logs                    [boolean] [default: false]
-  -h, --help     Show help                                             [boolean]
+  --version             Show version number                                   [boolean]
+  -s, --service         service-for path                                  [default: ""]
+  -b, --path            base path uri
+  -d, --dir             base dir                         [required] [default: "../app"]
+  -p, --port            listening port
+  -k, --key             server key                                        [default: ""]
+  -c, --cert            server cert                                       [default: ""]
+  -x, --pfx             server pfx                                        [default: ""]
+  -w, --pass            server pfx passphrase                             [default: ""]
+  -n, --keyring         keyring name                                      [default: ""]
+  -o, --keyring-owner   keyring owner id                                  [default: ""]
+  -l, --keyring-label   keyring certificate label                         [default: ""]
+  -f, --csp             csp whitelist ancestors frames                       [required]
+  -v, --verbose         show request logs                    [boolean] [default: false]
+  -h, --help            Show help                                             [boolean]
 ```
 
 ## Run Tests

--- a/README.md
+++ b/README.md
@@ -7,7 +7,14 @@ Provide simple HTTPS server to server Zowe Desktop Explorer plugins.
 ## Start Dev Server
 
 ```
-npm start
+// with key cert
+npm start -- -s "jes" -b "/" -d "public" -p "9090" -k "configs/server.key" -c "configs/server.cert"
+
+// with pfx pass
+npm start -- -s "jes" -b "/" -d "public" -p "9090" -x "configs/server.pfx" -w "pass"
+
+// with keyring
+npm start -- -s "jes" -b "/" -d "public" -p "9090" -n "keyring" -o "keyring-owner" -l "keyring-label"
 ```
 
 Then visit `https://localhost:9090` to access the test server. The default config file is `configs/config-default.json`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1286,6 +1286,11 @@
       "requires": {
         "graceful-fs": "^4.1.6"
       }
+    },"node-gyp-build": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.2.2.tgz",
+      "integrity": "sha512-Lqh7mrByWCM8Cf9UPqpeoVBBo5Ugx+RKu885GAzmLBVYjeywScxHXPGLa4JfYNZmcNGwzR0Glu5/9GaQZMFqyA==",
+      "optional": true
     },
     "keyring_js": {
       "version": "1.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1287,6 +1287,15 @@
         "graceful-fs": "^4.1.6"
       }
     },
+    "keyring_js": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/keyring_js/-/keyring_js-1.0.1.tgz",
+      "integrity": "sha512-A5vMeGoSHnFuveee7OjyNFJd9Mo+yZs4weLIhegCvBu/3OjgFUNmeWUFbM4NwX/FBz3/lGX4uB8E/jpgjd8VwA==",
+      "optional": true,
+      "requires": {
+        "node-gyp-build": "^4.2.1"
+      }
+    },
     "levn": {
       "version": "0.3.0",
       "resolved": "https://zowe.jfrog.io/zowe/api/npm/npm-release/levn/-/levn-0.3.0.tgz",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,9 @@
   "dependencies": {
     "stdio": "0.2.7"
   },
+  "optionalDependencies": {
+    "keyring_js": "~1.0.0"
+  },
   "devDependencies": {
     "abort-controller": "^3.0.0",
     "axios": "^0.19.0",

--- a/src/config.js
+++ b/src/config.js
@@ -90,7 +90,6 @@ function parseCsp(config) {
 }
 
 function loadHttpsCerts(config) {
-  const serviceFor = config.serviceFor;
   // load https type
   if (config && config.https) {
     if(config.https.type === HTTPS_TYPE.KEY_CERT) {

--- a/src/config.js
+++ b/src/config.js
@@ -111,8 +111,8 @@ function loadKeyCerts(config) {
   const serviceFor = config.serviceFor;
   try {
     ['key', 'cert'].forEach(key => {
-      let path = config.https[key];
-      config.https[key] = fs.readFileSync(path);
+      let filePath = config.https[key];
+      config.https[key] = fs.readFileSync(filePath);
     });
   } catch(err) {
     process.stderr.write(`[${serviceFor}] exception thrown when reading key cert files no such file or directory\n`);
@@ -124,8 +124,8 @@ function loadKeyCerts(config) {
 function loadPfx(config) {
   const serviceFor = config.serviceFor;
   try {
-    let path = config.https['pfx'];
-    config.https['pfx'] = fs.readFileSync(path);
+    let filePath = config.https['pfx'];
+    config.https['pfx'] = fs.readFileSync(filePath);
   } catch(err) {
     process.stderr.write(`[${serviceFor}] exception thrown when reading pfx no such file or directory\n`);
     process.exit(1);

--- a/src/config.js
+++ b/src/config.js
@@ -94,13 +94,10 @@ function loadHttpsCerts(config) {
   // load https type
   if (config && config.https) {
     if(config.https.type === HTTPS_TYPE.KEY_CERT) {
-      process.stdout.write(`[${serviceFor}] https using key cert\n`);
       config = loadKeyCerts(config);
     } else if(config.https.type === HTTPS_TYPE.PFX_PASS) {
-      process.stdout.write(`[${serviceFor}] https using pfx pass\n`);
       config = loadPfx(config);
     } else if(config.https.type === HTTPS_TYPE.KEYRING) {
-      process.stdout.write(`[${serviceFor}] https using keyring\n`);
       config = loadKeyringCerts(config);
     }
   }

--- a/src/index.js
+++ b/src/index.js
@@ -12,7 +12,7 @@
 
 // load command line params
 const stdio = require('stdio');
-const {httpTypeToString} = require('./utils');
+const { httpTypeToString } = require('./utils');
 
 const params = stdio.getopt({
   'service': {key: 's',  args:1, description: 'service-for path', default:'', type: 'string'},

--- a/src/index.js
+++ b/src/index.js
@@ -22,6 +22,9 @@ const params = stdio.getopt({
   'pfx': {key: 'x', args:1, description: 'server pfx', default:''},
   'pass': {key: 'w', args:1, description: 'server pfx passphrase', default:''},
   'csp': {key: 'f', args:1, description: 'csp whitelist ancestors frames', default:''},
+  'keyring': {key: 'n', args:1, description: 'keyring name', default:''},
+  'keyring-owner': {key: 'o', args:1, description: 'keyring owner id', default:''},
+  'keyring-label': {key: 'l', args:1, description: 'keyring certificate label', default:''},
   'verbose': {key: 'v', default:false}
 });
 

--- a/src/index.js
+++ b/src/index.js
@@ -12,6 +12,8 @@
 
 // load command line params
 const stdio = require('stdio');
+const {httpTypeToString} = require('./utils');
+
 const params = stdio.getopt({
   'service': {key: 's',  args:1, description: 'service-for path', default:'', type: 'string'},
   'path': {key: 'b', args:1,    description: 'base path uri', default:''},
@@ -27,19 +29,21 @@ const params = stdio.getopt({
   'keyring-label': {key: 'l', args:1, description: 'keyring certificate label', default:''},
   'verbose': {key: 'v', default:false}
 });
+const serviceFor = params.service;
 
 // load config
 let config;
-const serviceFor = params.service;
 try {
   config = require('./config')(params);
-  process.stdout.write(`[${serviceFor}]: rootDir ${config.rootDir}\n`);
-  process.stdout.write(`[${serviceFor}]: version ${config.version}\n`);
-  process.stdout.write(`[${serviceFor}]: script name ${config.scriptName}\n`);
-  process.stdout.write(`[${serviceFor}]: paths ${JSON.stringify(config.paths)}\n`);
-} catch (err) {
-  process.stderr.write(`[${serviceFor}]:failed to process config\n`);
-  process.stderr.write(`[${serviceFor}]:${err}\n\n`);
+  process.stdout.write(`[${serviceFor}] rootDir ${config.rootDir}\n`);
+  process.stdout.write(`[${serviceFor}] version ${config.version}\n`);
+  process.stdout.write(`[${serviceFor}] script name ${config.scriptName}\n`);
+  process.stdout.write(`[${serviceFor}] paths ${JSON.stringify(config.paths)}\n`);
+  process.stdout.write(`[${serviceFor}] port ${JSON.stringify(config.port)}\n`);
+  process.stdout.write(`[${serviceFor}] https using ${httpTypeToString(config.https.type)}\n`);
+} catch (err)  {
+  process.stderr.write(`[${serviceFor}] failed to process config\n`);
+  process.stderr.write(`[${serviceFor}] ${err}\n\n`);
   process.exit(1);
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -30,16 +30,16 @@ const params = stdio.getopt({
 
 // load config
 let config;
+const serviceFor = params.service;
 try {
   config = require('./config')(params);
-  process.stdout.write(`[rootDir]:${config.rootDir}\n`);
-  process.stdout.write(`[version]:${config.version}\n`);
-  process.stdout.write(`[script name]:${config.scriptName}\n`);
-  process.stdout.write(`[serviceFor]:${config.serviceFor}\n`);
-  process.stdout.write(`[paths]:${JSON.stringify(config.paths)}\n`);
+  process.stdout.write(`[${serviceFor}]: rootDir ${config.rootDir}\n`);
+  process.stdout.write(`[${serviceFor}]: version ${config.version}\n`);
+  process.stdout.write(`[${serviceFor}]: script name ${config.scriptName}\n`);
+  process.stdout.write(`[${serviceFor}]: paths ${JSON.stringify(config.paths)}\n`);
 } catch (err) {
-  process.stderr.write('failed to process config\n');
-  process.stderr.write(`${err}\n\n`);
+  process.stderr.write(`[${serviceFor}]:failed to process config\n`);
+  process.stderr.write(`[${serviceFor}]:${err}\n\n`);
   process.exit(1);
 }
 

--- a/src/server.js
+++ b/src/server.js
@@ -3,7 +3,7 @@ const { constants: cryptoConstants } = require('crypto');
 const { HTTPS_TYPE } = require('./utils');
 
 
-function getHttpsConfig(config) {
+function extractHttpsConfigFromConfig(config) {
   let httpsConfig = {};
   if(config.https.type === HTTPS_TYPE.KEY_CERT || config.https.type === HTTPS_TYPE.KEYRING) {
     httpsConfig = {
@@ -41,7 +41,7 @@ function createHttpsServer (config, requestHandler) {
     'ECDHE-ECDSA-AES128-SHA256',
     'ECDHE-ECDSA-AES256-SHA384'].join(':');
 
-  const httpsConfig = getHttpsConfig(config);
+  const httpsConfig = extractHttpsConfigFromConfig(config);
   const httpsServer = https.createServer(httpsConfig, requestHandler);
   return httpsServer;
 }

--- a/src/server.js
+++ b/src/server.js
@@ -1,5 +1,23 @@
 const https = require('https');
 const { constants: cryptoConstants } = require('crypto');
+const { HTTPS_TYPE } = require('./utils');
+
+
+function getHttpsConfig(config) {
+  let httpsConfig = {};
+  if(config.https.type === HTTPS_TYPE.KEY_CERT || config.https.type === HTTPS_TYPE.KEYRING) {
+    httpsConfig = {
+      key: config.https.key,
+      cert: config.https.cert
+    };
+  } else if(config.https.type === HTTPS_TYPE.PFX_PASS) {
+    httpsConfig = {
+      pfx: config.https.pfx,
+      passphrase: config.https.passphrase
+    };
+  }
+  return httpsConfig;
+}
 
 function createHttpsServer (config, requestHandler) {
   if (!config.https ||
@@ -23,10 +41,10 @@ function createHttpsServer (config, requestHandler) {
     'ECDHE-ECDSA-AES128-SHA256',
     'ECDHE-ECDSA-AES256-SHA384'].join(':');
 
-  const httpsServer = https.createServer(config.https, requestHandler);
+  const httpsConfig = getHttpsConfig(config);
+  const httpsServer = https.createServer(httpsConfig, requestHandler);
   return httpsServer;
 }
-
 
 module.exports = (config, requestHandler) => {
   const httpsServer = createHttpsServer(config, requestHandler);

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,0 +1,9 @@
+const HTTPS_TYPE = {
+  KEY_CERT: 1,
+  PFX_PASS: 2,
+  KEYRING: 3
+};
+
+module.exports = {
+  HTTPS_TYPE
+};

--- a/src/utils.js
+++ b/src/utils.js
@@ -4,6 +4,19 @@ const HTTPS_TYPE = {
   KEYRING: 3
 };
 
+const httpTypeToString = (type) => {
+  if(type === HTTPS_TYPE.KEY_CERT) {
+    return 'KEY_CERT';
+  }
+  if(type === HTTPS_TYPE.PFX_PASS) {
+    return 'PFX_PASS';
+  }
+  if(type === HTTPS_TYPE.KEYRING) {
+    return 'KEYRING';
+  }
+};
+
 module.exports = {
-  HTTPS_TYPE
+  HTTPS_TYPE,
+  httpTypeToString
 };

--- a/test/https-combos/allHttpsType.json
+++ b/test/https-combos/allHttpsType.json
@@ -9,6 +9,9 @@
     "key": "configs/server.key",
     "cert": "configs/server.cert",
     "pfx": "configs/server.pfx",
-    "passphrase": "pass"
+    "passphrase": "pass",
+    "keyring": "keyring",
+    "keyring-owner": "owner",
+    "keyring-label": "label"
   }
 }

--- a/test/https-combos/fail_onlykeyring.json
+++ b/test/https-combos/fail_onlykeyring.json
@@ -6,8 +6,6 @@
   }],
   "port": 9090,
   "https": {
-    "key": "configs/server.key",
-    "cert": "configs/server.cert",
-    "passphrase": "pass"
+    "keyring": "keyring"
   }
 }

--- a/test/https-combos/fail_onlykeyringlabel.json
+++ b/test/https-combos/fail_onlykeyringlabel.json
@@ -6,8 +6,6 @@
   }],
   "port": 9090,
   "https": {
-    "cert": "configs/server.cert",
-    "pass": "pass",
-    "keyring": "keyring"
+    "keyring-label": "keyring"
   }
 }

--- a/test/https-combos/fail_onlykeyringowner.json
+++ b/test/https-combos/fail_onlykeyringowner.json
@@ -6,8 +6,6 @@
   }],
   "port": 9090,
   "https": {
-    "cert": "configs/server.cert",
-    "pass": "pass",
-    "keyring": "keyring"
+    "keyring-owner": "keyring"
   }
 }

--- a/test/https-combos/keyring.json
+++ b/test/https-combos/keyring.json
@@ -6,8 +6,8 @@
   }],
   "port": 9090,
   "https": {
-    "cert": "configs/server.cert",
-    "pass": "pass",
-    "keyring": "keyring"
+    "keyring": "keyring",
+    "keyring-owner": "configs/server.key",
+    "keyring-label": "configs/server.cert"
   }
 }

--- a/test/https-combos/test-https-combo.js
+++ b/test/https-combos/test-https-combo.js
@@ -56,19 +56,19 @@ describe('test https combos', function() {
     await initTest('key.json');
     await testSuccessResponse();
   });
-
-  it('using key-cert-pass should return index.html when requesting /', async function() {
-    await initTest('keyWithPass.json');
-    await testSuccessResponse();
-  });
   
   it('using pfx-pass should return index.html when requesting /', async function() {
     await initTest('pfx.json');
     await testSuccessResponse();
   });
 
-  it('using both-key-cert-pfx-pass should return index.html when requesting /', async function() {
-    await initTest('bothKeyPass.json');
+  it('using all-key-cert-pfx-keyring should return index.html when requesting /', async function() {
+    await initTest('allHttpsType.json');
+    await testSuccessResponse();
+  });
+
+  it.skip('using keyring should return index.html when requesting /', async function() {
+    await initTest('keyring.json');
     await testSuccessResponse();
   });
 
@@ -88,7 +88,19 @@ describe('test https combos', function() {
     await testFailedResponse('fail_onlycert.json');
   });
 
-  it('using only cert should fail on start', async function() {
+  it('using only keyring should fail on start', async function() {
+    await testFailedResponse('fail_onlykeyring.json');
+  });
+
+  it('using only keyring-owner should fail on start', async function() {
+    await testFailedResponse('fail_onlykeyringowner.json');
+  });
+
+  it('using only keyring-label should fail on start', async function() {
+    await testFailedResponse('fail_onlykeyringlabel.json');
+  });
+
+  it('using random combo should fail on start', async function() {
     await testFailedResponse('fail_randomcombo.json');
   });
 });

--- a/test/utils.js
+++ b/test/utils.js
@@ -123,6 +123,22 @@ const buildParams = (configPath) => {
       params.push('-w');
       params.push(config['https']['passphrase']);
     }
+
+    if(httpsConfig['keyring']) {
+      params.push('-n');
+      params.push(config['https']['keyring']);
+    }
+
+    if(httpsConfig['keyring-owner']) {
+      params.push('-o');
+      params.push(config['https']['keyring-owner']);
+    }
+
+    if(httpsConfig['keyring-label']) {
+      params.push('-l');
+      params.push(config['https']['keyring-label']);
+    }
+
   }
   return params;
 };


### PR DESCRIPTION
adds ability to load certificates from keyrings on z/OS
new options:
-n, --keyring keyring name
-o, --keyring-owner keyring owner id
-l, --keyring-label keyring certificate label

keyring options are used when certificates are not loaded via -c and -k options