### PR TITLE
ignore boolean params where string in needed to try other options

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "explorer-ui-server",
-  "version": "0.2.12",
+  "version": "0.2.13",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "explorer-ui-server",
-  "version": "0.2.12",
+  "version": "0.2.13",
   "description": "HTTP Server to host static files",
   "author": "IBM",
   "license": "EPL-2.0",

--- a/src/config.js
+++ b/src/config.js
@@ -62,11 +62,11 @@ function validateParams (params) {
 }
 
 function whichHttpsType(params) {
-  if(params.key>'' && params.cert>'') {
+  if(params.key>'' && params.cert>'' && typeof params.key === 'string' && typeof params.cert === 'string') {
     return HTTPS_TYPE.KEY_CERT;
   }
 
-  if(params.pfx>'' && params.pass>'') {
+  if(params.pfx>'' && params.pass>'' && typeof params.pfx === 'string' && typeof params.pass === 'string') {
     return HTTPS_TYPE.PFX_PASS;
   }
 


### PR DESCRIPTION
Signed-off-by: js665999 <js665999@broadcom.com>

fixes issue of wrong type of params https://github.com/zowe/explorer-uss/pull/88#discussion_r453751636